### PR TITLE
fix: compitable domain suffix

### DIFF
--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -143,7 +143,7 @@ inputs:
       imageUrl:
         type: string
         required: true
-        regex: '([a-z0-9-]{5,50}).tencentcloudcr.com\/([a-z-_.0-9]{2,30})\/([a-z0-9-_.\/]{2,200}):([\w-]+)@sha256:(\w+)'
+        regex: '([a-z0-9-]{5,50}).(tencentcloudcr|tencentyun).com\/([a-z-_.0-9]{2,30})\/([a-z0-9-_.\/]{2,200}):([\w-]+)@sha256:(\w+)'
         message: '镜像地址 imageUrl 格式需要遵守: {domain}/{namespace}/{imageName}:{tag}@{digest}'
   installDependency:
     type: boolean


### PR DESCRIPTION
- ticket: https://app.asana.com/0/0/1201191454354360/1201452647439473/f

*imageUrl* 需要兼容个人版和企业版的domain判断.

因为image部署情况对其他字段的影响还未确定，所以在服务端进行处理: 只要配置了 image 字段就先跳过了校验。
相关ticket ： https://app.asana.com/0/1200011502754281/1201443739615622, https://app.asana.com/0/1200011502754281/1201471236882615
