### PR TITLE
fix: remove max, min limit for whitelist

### DIFF
--- a/http@0.0.1.yml
+++ b/http@0.0.1.yml
@@ -89,8 +89,6 @@ inputs:
         level: 'warning'
       memorySize:
         type: number
-        min: 64
-        max: 3072
         message: '可选范围 64、128MB-3072MB，并且以 128MB 为阶梯'
         allow:
           - 64

--- a/multi-scf@0.0.1.yml
+++ b/multi-scf@0.0.1.yml
@@ -39,8 +39,6 @@ inputs:
       - CustomRuntime
   memorySize:
     type: number
-    min: 64
-    max: 3072
     message: '可选范围 64、128MB-3072MB，并且以 128MB 为阶梯'
     allow:
       - 64

--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -54,8 +54,6 @@ inputs:
       - na-toronto
   memorySize:
     type: number
-    min: 64
-    max: 3072
     message: '可选范围 64、128MB-3072MB，并且以 128MB 为阶梯'
     allow:
       - 64


### PR DESCRIPTION
Remove `min, max` for memorySize, they should just use `allow` as limitation.