### PR TITLE
feat: update validation rules for tencent-scf component

### DIFF
--- a/http@0.0.1.yml
+++ b/http@0.0.1.yml
@@ -3,14 +3,14 @@
 inputs:
   type:
     type: string
-    message: 'type 无法识别,当前只支持 event 和 web'
+    message: '不支持当前类型，支持类型有：【 event , web 】'
     allow:
       - event
       - web
   region:
     type: string
     message: >-
-      地区选择错误，https://cloud.tencent.com/document/api/583/17238#.E5.9C.B0.E5.9F.9F.E5.88.97.E8.A1.A8
+      不支持指定的地域 ，请查看腾讯地域列表获取所有支持的地域信息. https://cloud.tencent.com/document/api/583/17238#.E5.9C.B0.E5.9F.9F.E5.88.97.E8.A1.A8
     allow:
       - ap-beijing
       - ap-chengdu
@@ -153,7 +153,7 @@ inputs:
               - https
       environment:
         type: string
-        message: '发布环境选择错误，当前只支持 test, prepub, release'
+        message: '不支持该环境，支持的环境有：【  test , prepub , release 】'
         allow:
           - test
           - prepub
@@ -269,7 +269,7 @@ inputs:
             type: boolean
           refreshType:
             type: string
-            message: CDN 刷新类型，可选 delete：刷新全部资源，flush：刷新变更资源
+            message: 不支持该刷新类型，支持的刷新类型有：【 delete（刷新全部资源），flush（刷新变更资源）】
             allow:
               - delete
               - flush
@@ -284,7 +284,7 @@ inputs:
                   - 'off'
               redirectType:
                 type: string
-                message: 访问强制跳转类型，http：强制 http 跳转，https：强制 https 跳转
+                message: 不支持该强制跳转类型，支持的类型有：【 http （强制 http 跳转）, https （强制 https 跳转）】
                 allow:
                   - http
                   - https

--- a/multi-scf@0.0.1.yml
+++ b/multi-scf@0.0.1.yml
@@ -5,7 +5,7 @@
 inputs:
   region:
     type: string
-    message: '地区选择错误，https://cloud.tencent.com/document/api/583/17238#.E5.9C.B0.E5.9F.9F.E5.88.97.E8.A1.A8'
+    message: '不支持指定的地域 ，请查看腾讯地域列表获取所有支持的地域信息。https://cloud.tencent.com/document/api/583/17238#.E5.9C.B0.E5.9F.9F.E5.88.97.E8.A1.A8'
     allow:
       - ap-beijing
       - ap-chengdu
@@ -24,7 +24,7 @@ inputs:
       - na-toronto
   runtime:
     type: string
-    message: '运行时选择错误，请参考https://cloud.tencent.com/document/product/583/54977'
+    message: '不支持当前运行时，请参考腾讯语言和运行时支持信息。请参考https://cloud.tencent.com/document/product/583/54977'
     allow:
       - Python2.7
       - Python3.6

--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -162,10 +162,16 @@ inputs:
         type: object
         keys:
           idleTimeOut:
-            message: '超时时间取值范围为 【 1（秒）- 1800（秒）】'
+            message: 'idleTimeOut 空闲超时时间的取值范围为 【 1（秒）- 1800（秒）】'
             type: number
             min: 1
             max: 1800
+  provisionedNum:
+    type: number
+    max: 100
+    message: "provisionedNum 预置并发数量的上限为 100"
+  qualifier:
+    type: number
   asyncRunEnable:
     type: boolean
   l5Enable:

--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -151,6 +151,21 @@ inputs:
         message: '镜像地址 imageUrl 格式需要遵守: {domain}/{namespace}/{imageName}:{tag}@{digest}'
   installDependency:
     type: boolean
+  protocolType:
+    type: string
+    allow:
+      - WS # inputs.type = web 时才会生效
+  protocolParams:
+    type: object
+    keys:
+      wsParams:
+        type: object
+        keys:
+          idleTimeOut:
+            message: '超时时间取值范围为 【 1（秒）- 1800（秒）】'
+            type: number
+            min: 1
+            max: 1800
   asyncRunEnable:
     type: boolean
   l5Enable:

--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -3,7 +3,7 @@
 inputs:
   type:
     type: string
-    message: 'type 无法识别,当前只支持 event 和 web'
+    message: '不支持当前类型，支持类型有：[event , web]'
     allow:
       - event
       - web


### PR DESCRIPTION
Close: https://app.asana.com/0/1200011502754281/1201635112768117/f
---
`tencent-scf` 组件发布了websocket 和预置并发配置两个功能，需要添加对应的字段校验:
1. `websocket`[功能字段](https://github.com/serverless-components/tencent-scf/commit/f97cd6ee25651c42f5207898f13d4d3d16a9a4d5#diff-033666d17642ae1f8661f3ac5b308045dbe91fffb8dac151f16b13471dd52f4c): [`7a0f272` (#22)](https://github.com/serverless-components/tencent-types/pull/22/commits/7a0f272f935d9b91f54453d7f21a2786ae547bef)
2. `预置并发`[功能字段](https://github.com/serverless-components/tencent-scf/pull/89): [`6a14006` (#22)](https://github.com/serverless-components/tencent-types/pull/22/commits/6a140069db39fda3264c9c6718f0a5acd986d2d3)