### PR TITLE
fix:update scf component param validation

### DIFF
--- a/scf@0.0.4.yml
+++ b/scf@0.0.4.yml
@@ -117,9 +117,9 @@ inputs:
     level: 'warning'
   initTimeout:
     type: number
-    min: 1
-    max: 30
-    message: '函数初始化超时时间，单位为秒，可选值范围 1-30 秒'
+    min: 3
+    max: 300
+    message: '函数初始化超时时间，单位为秒，可选值范围 3-300 秒'
     level: 'warning'
   cfs:
     type: array
@@ -208,8 +208,6 @@ inputs:
                   cronExpression:
                     type: string
                     required: true
-                  argument:
-                    type: string
           apigw:
             type: object
             keys:


### PR DESCRIPTION
fix:
1、initTimeout参数范围
2、删除timer触发器参数argument的校验，使其可为空